### PR TITLE
fix address find in contentEditable elements

### DIFF
--- a/src/content_script/utils.js
+++ b/src/content_script/utils.js
@@ -154,7 +154,7 @@ function quickFilterNode(node) {
                             ignoreNodeList.indexOf(node.parentNode.nodeName) > -1 || // check if in ignoreNodeList
                             node.length < 35 ||  // arbitrary too short for address 
                             node.data.search(regexBCHExact) < 0 || // address found in text
-                            (node.parentNode.hasOwnProperty('contentEditable') && node.parentNode.contentEditable === 'true'); // elements that act as inputs
+                            (node.parentNode.hasAttribute('contentEditable') && node.parentNode.contentEditable === 'true'); // elements that act as inputs
         return returnValue;
     } catch (error) {
         // error filtering. reject default


### PR DESCRIPTION
Resolves #1 issue of found addresses in content editable element inputs by replacing the incorrect method 'hasOwnProperty' with 'hasAttribute'.